### PR TITLE
Trv41

### DIFF
--- a/database.cpp
+++ b/database.cpp
@@ -3759,6 +3759,7 @@ static int sqliteLoadAllSensorsCallback(void *user, int ncols, char **colval , c
                     R_GetProductId(&sensor) == QLatin1String("Tuya_THD GS361A-H04 TRV") ||
                     R_GetProductId(&sensor) == QLatin1String("Tuya_THD SEA801-ZIGBEE TRV") ||
                     R_GetProductId(&sensor) == QLatin1String("Tuya_THD Smart radiator TRV") ||
+                    R_GetProductId(&sensor) == QLatin1String("Tuya_THD BRT-100") ||
                     R_GetProductId(&sensor) == QLatin1String("Tuya_THD WZB-TRVL TRV"))
                 {
                     sensor.addItem(DataTypeUInt8, RStateValve);

--- a/thermostat.cpp
+++ b/thermostat.cpp
@@ -98,7 +98,7 @@ const std::array<KeyValMapTuyaSingle, 3> RConfigModeValuesTuya1 = { { {QLatin1St
 
 const std::array<KeyValMapTuyaSingle, 2> RConfigModeValuesTuya2 = { { {QLatin1String("off"), {0x00}}, {QLatin1String("heat"), {0x01}} } };
 
-const std::array<KeyValMapTuyaSingle, 4> RConfigModeValuesTuya3 = { { {QLatin1String("auto"), {0x00}}, {QLatin1String("manual"), {0x01}}, {QLatin1String("temporary_manual"), {0x02}}, {QLatin1String("holiday"), {0x03}} } };
+const std::array<KeyValMapTuyaSingle, 4> RConfigModeValuesTuya3 = { { {QLatin1String("auto"), {0x00}}, {QLatin1String("manual"), {0x01}}, {QLatin1String("boost"), {0x02}}, {QLatin1String("holiday"), {0x03}}} };
 
 const std::array<KeyValMapTuyaSingle, 2> RConfigModeValuesTuya4 = { { {QLatin1String("auto"), {0x00}}, {QLatin1String("heat"), {0x01}} } };
 

--- a/tuya.cpp
+++ b/tuya.cpp
@@ -1130,18 +1130,8 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                     case 0x0268 : // Valve position in % for Moe
                     {
                         quint8 valve = static_cast<qint8>(data & 0xFF);
-                        bool on = valve > 3;
 
-                        ResourceItem *item = sensorNode->item(RStateOn);
-                        if (item)
-                        {
-                            if (item->toBool() != on)
-                            {
-                                item->setValue(on);
-                                enqueueEvent(Event(RSensors, RStateOn, sensorNode->id(), item));
-                            }
-                        }
-                        item = sensorNode->item(RStateValve);
+                        ResourceItem *item = sensorNode->item(RStateValve);
                         if (item && item->toNumber() != valve)
                         {
                             item->setValue(valve);
@@ -1305,6 +1295,21 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         }
                     }
                     break;
+                    case 0x0407 : // valve open / closed for Moes
+                    {
+                        bool on = data < 0x01; // 0x01 = off, 0x00 = on
+
+                        ResourceItem *item = sensorNode->item(RStateOn);
+                        if (item)
+                        {
+                            if (item->toBool() != on)
+                            {
+                                item->setValue(on);
+                                enqueueEvent(Event(RSensors, RStateOn, sensorNode->id(), item));
+                            }
+                        }
+                    }
+                        break;
                     case 0x046a : // Force mode : normal/open/close
                     {
                         QString mode;


### PR DESCRIPTION
Tuya_THD BRT-100
- change state: on from valve opening in percent to valve symbol showing (more reliable)
- add state: valve (valve opening setting in percent)
- change boost mode to preset (device: boost <=> preset:boost)
- change away mode to preset
- change modes
   - device: mode: auto <=> mode: auto, preset: auto
   - device: mode: manual <=> mode: heat, preset: manual
   - device: mode: holiday: <=> mode: auto, preset: holiday)
- add reverse of dake "off" mode (mode: "off" => mode: "heat" increase temperature from 5°C to 20°C)