### PR TITLE
add childlock

### DIFF
--- a/tuya.cpp
+++ b/tuya.cpp
@@ -857,6 +857,19 @@ void DeRestPluginPrivate::handleTuyaClusterIndication(const deCONZ::ApsDataIndic
                         }
                     }
                     break;
+					case 0x010D : // Childlock status for BRT-100
+                    {
+                        bool locked = (data == 0) ? false : true;
+                        ResourceItem *item = sensorNode->item(RConfigLocked);
+
+                        if (item && item->toBool() != locked)
+                        {
+                            item->setValue(locked);
+                            Event e(RSensors, RConfigLocked, sensorNode->id(), item);
+                            enqueueEvent(e);
+                        }
+                    }
+                    break;
                     case 0x010E : // Woox Low Battery
                     {
                         bool lowbat = (data == 0) ? false : true;


### PR DESCRIPTION
was missing, but is unused in HA
device => HA is working
HA => device I can not test, don't know how to send from HA "config: locked: true/false"